### PR TITLE
updated url to point at local server rather than only prod

### DIFF
--- a/spotlight/config/routes.rb
+++ b/spotlight/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   mount Spotlight::Engine, at: 'spotlight'
   mount Blacklight::Engine => '/'
 
-  get '/downloads/:id', to: redirect { |params, request| "https://digital.wpi.edu/downloads/#{request.params[:id]}?#{request.params.except(:id).to_query}" }
+  get '/downloads/:id', to: redirect { |params, request| "https://#{ENV['SERVERNAME'].to_s}/downloads/#{request.params[:id]}?#{request.params.except(:id).to_query}" }
 
   concern :searchable, Blacklight::Routes::Searchable.new
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
I only updated the url in the routes file. I thought there were more, but I realized it was files where it was removed. I didn't do it here, but if needed later I can add an initializer file to set the root url for exhibits and digital.